### PR TITLE
don't import EML if message has attachments

### DIFF
--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -624,8 +624,8 @@ class MailAccountHandler(LoggingMixin):
 
         if (
             rule.consumption_scope == MailRule.ConsumptionScope.EML_ONLY
-            or rule.consumption_scope == MailRule.ConsumptionScope.EVERYTHING
-        ):
+            and not message.attachments
+        ) or rule.consumption_scope == MailRule.ConsumptionScipe.EVERYTHING:
             processed_elements += self._process_eml(
                 message,
                 rule,


### PR DESCRIPTION
## Proposed change

I would like to be able to only import messages as .eml if they don't have attachments.
I have 2 rules. one only importing attachments and one that should only match if a message has no attachments. I was of the opinion that if a mail rule matches, the following rules won't apply (especially if the mail is marked as processed) but that doesn't seem to be the case as well.

i may be wrong but selecting consumption scope EML_ONLY should skip a message in that case.

Closes #4471

## Type of change

- [ ] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [X] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

- [X] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [X] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [X] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [X] I have made corresponding changes to the documentation as needed.
- [X] I have checked my modifications for any breaking changes.
